### PR TITLE
BOT-20: organiser auto-confirmed as participant

### DIFF
--- a/internal/adapters/discord/modal.go
+++ b/internal/adapters/discord/modal.go
@@ -166,7 +166,7 @@ func (h *Handler) HandleModalSubmit(s *discordgo.Session, i *discordgo.Interacti
 	}
 
 	ctx := context.Background()
-	if err := h.eventUseCase.CreateEvent(ctx, event); err != nil {
+	if err := h.eventUseCase.CreateEvent(ctx, event, displayName); err != nil {
 		log.Printf("❌ Erreur lors de la sauvegarde de l'événement: %v", err)
 		s.FollowupMessageCreate(i.Interaction, true, &discordgo.WebhookParams{
 			Content: "❌ Erreur lors de la sauvegarde de l'événement.",

--- a/internal/ports/input/event.go
+++ b/internal/ports/input/event.go
@@ -7,7 +7,7 @@ import (
 )
 
 type EventUseCase interface {
-	CreateEvent(ctx context.Context, event *entities.Event) error
+	CreateEvent(ctx context.Context, event *entities.Event, creatorUsername string) error
 	GetEventByMessageID(ctx context.Context, messageID string) (*entities.Event, error)
 	GetEventByID(ctx context.Context, id uint) (*entities.Event, error)
 	UpdateEvent(ctx context.Context, event *entities.Event) error

--- a/pkg/discord/embed.go
+++ b/pkg/discord/embed.go
@@ -35,10 +35,14 @@ func buildDescriptionBase(organizerMention, description string, scheduledAt time
 	return b.String()
 }
 
+// BuildNewEventEmbed builds the initial post embed with the organizer
+// already counted as a confirmed participant (e.g. 1/4) and listed
+// in the participants section.
 func BuildNewEventEmbed(creatorID, description string, scheduledAt time.Time, slots int, displayName, avatarURL string) *discordgo.MessageEmbed {
 	userMention := fmt.Sprintf("<@%s>", creatorID)
-	placesText := formatPlaces(slots, 0)
+	placesText := formatPlaces(slots, 1)
 	desc := buildDescriptionBase(userMention, description, scheduledAt, placesText)
+	desc += "\n\n✅ **Participants :**\n- " + userMention
 	return &discordgo.MessageEmbed{
 		Title:       embedTitle,
 		Description: desc,


### PR DESCRIPTION
- Add organiser as CONFIRMED participant on event creation in EventService
- Include organiser in initial embed count and participant list (1/slots)
- Pass creator display name into CreateEvent via EventUseCase