### PR TITLE
feat(BOT-23): validation organisateur — MP tri Cas A/B + scheduler H-48

### DIFF
--- a/internal/adapters/discord/handler.go
+++ b/internal/adapters/discord/handler.go
@@ -8,16 +8,19 @@ type Handler struct {
 	eventUseCase       input.EventUseCase
 	participantUseCase input.ParticipantUseCase
 	forumChannelID     string
+	guildID            string
 }
 
 func NewHandler(
 	eventUseCase input.EventUseCase,
 	participantUseCase input.ParticipantUseCase,
 	forumChannelID string,
+	guildID string,
 ) *Handler {
 	return &Handler{
 		eventUseCase:       eventUseCase,
 		participantUseCase: participantUseCase,
 		forumChannelID:     forumChannelID,
+		guildID:            guildID,
 	}
 }

--- a/internal/adapters/discord/organizer_validation.go
+++ b/internal/adapters/discord/organizer_validation.go
@@ -1,0 +1,312 @@
+package discord
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log"
+	"strconv"
+	"strings"
+	"time"
+
+	"servbot/internal/domain"
+	"servbot/internal/domain/entities"
+	pkgdiscord "servbot/pkg/discord"
+
+	"github.com/bwmarrin/discordgo"
+)
+
+const organizerValidationWindow = 48 * time.Hour
+
+func isCasA(eventScheduledAt time.Time, now time.Time) bool {
+	return !eventScheduledAt.IsZero() && eventScheduledAt.Sub(now) > organizerValidationWindow
+}
+
+func isCasB(eventScheduledAt time.Time, now time.Time) bool {
+	return !eventScheduledAt.IsZero() && eventScheduledAt.After(now) && eventScheduledAt.Sub(now) <= organizerValidationWindow
+}
+
+func (h *Handler) messageLink(channelID, messageID string) string {
+	if h.guildID == "" || channelID == "" || messageID == "" {
+		return ""
+	}
+	return fmt.Sprintf("https://discord.com/channels/%s/%s/%s", h.guildID, channelID, messageID)
+}
+
+func (h *Handler) buildOrganizerTriDMContent(event *eventWithParticipants) string {
+	participantsSansOrga := make([]entities.Participant, 0, len(event.Participants))
+	for _, p := range event.Participants {
+		if p.UserID != event.CreatorID {
+			participantsSansOrga = append(participantsSansOrga, p)
+		}
+	}
+	confirmed, waitlist := pkgdiscord.FormatParticipants(participantsSansOrga)
+	var b strings.Builder
+	if link := h.messageLink(event.ChannelID, event.MessageID); link != "" {
+		b.WriteString(fmt.Sprintf("**Tri pour la sortie :** [%s](%s)\n\n", event.Title, link))
+	} else {
+		b.WriteString(fmt.Sprintf("**Tri pour la sortie : %s**\n\n", event.Title))
+	}
+	if !event.ScheduledAt.IsZero() {
+		b.WriteString(fmt.Sprintf("📅 %s\n\n", pkgdiscord.FormatEventDateTime(event.ScheduledAt)))
+	}
+	if len(confirmed) > 0 {
+		b.WriteString("✅ **Potentiels intéressés confirmés :**\n")
+		for _, line := range confirmed {
+			b.WriteString(line + "\n")
+		}
+		b.WriteString("\n")
+	}
+	if len(waitlist) > 0 {
+		b.WriteString("⏳ **Potentiels intéressés en attente :**\n")
+		for _, line := range waitlist {
+			b.WriteString(line + "\n")
+		}
+	}
+	b.WriteString("\nClique sur **Finaliser l'étape 1** quand tu as validé la liste.")
+	return b.String()
+}
+
+type eventWithParticipants struct {
+	ID                          uint
+	MessageID                   string
+	ChannelID                   string
+	CreatorID                   string
+	Title                       string
+	Description                 string
+	MaxSlots                    int
+	ScheduledAt                 time.Time
+	OrganizerValidationDMSentAt time.Time
+	OrganizerStep1FinalizedAt   time.Time
+	Participants                []entities.Participant
+}
+
+func (h *Handler) sendOrganizerValidationDM(s *discordgo.Session, event *eventWithParticipants) error {
+	ch, err := s.UserChannelCreate(event.CreatorID)
+	if err != nil || ch == nil {
+		return fmt.Errorf("create organizer DM channel: %w", err)
+	}
+	content := h.buildOrganizerTriDMContent(event)
+	components := []discordgo.MessageComponent{
+		discordgo.ActionsRow{
+			Components: []discordgo.MessageComponent{
+				discordgo.Button{
+					Label:    "Finaliser l'étape 1",
+					Style:    discordgo.SuccessButton,
+					CustomID: fmt.Sprintf("btn_organizer_finalize_%d", event.ID),
+				},
+			},
+		},
+	}
+	_, err = s.ChannelMessageSendComplex(ch.ID, &discordgo.MessageSend{
+		Content:    content,
+		Components: components,
+	})
+	return err
+}
+
+func (h *Handler) sendOrganizerAcceptRefuseDM(s *discordgo.Session, eventTitle, organizerID, channelID, messageID string, participant *entities.Participant) error {
+	ch, err := s.UserChannelCreate(organizerID)
+	if err != nil || ch == nil {
+		return fmt.Errorf("create organizer DM channel: %w", err)
+	}
+	var content string
+	if link := h.messageLink(channelID, messageID); link != "" {
+		content = fmt.Sprintf("**Nouvelle inscription pour :** [%s](%s)\n\n<@%s> (%s) s'est déclaré potentiellement intéressé.\n\nAccepter ou refuser ce potentiel intéressé ?", eventTitle, link, participant.UserID, participant.Username)
+	} else {
+		content = fmt.Sprintf("**Nouvelle inscription pour : %s**\n\n<@%s> (%s) s'est déclaré potentiellement intéressé.\n\nAccepter ou refuser ce potentiel intéressé ?", eventTitle, participant.UserID, participant.Username)
+	}
+	components := []discordgo.MessageComponent{
+		discordgo.ActionsRow{
+			Components: []discordgo.MessageComponent{
+				discordgo.Button{
+					Label:    "Accepter",
+					Style:    discordgo.SuccessButton,
+					CustomID: fmt.Sprintf("btn_organizer_accept_%d", participant.ID),
+				},
+				discordgo.Button{
+					Label:    "Refuser",
+					Style:    discordgo.DangerButton,
+					CustomID: fmt.Sprintf("btn_organizer_refuse_%d", participant.ID),
+				},
+			},
+		},
+	}
+	_, err = s.ChannelMessageSendComplex(ch.ID, &discordgo.MessageSend{
+		Content:    content,
+		Components: components,
+	})
+	return err
+}
+
+func eventToEventWithParticipants(e *entities.Event) *eventWithParticipants {
+	if e == nil {
+		return nil
+	}
+	return &eventWithParticipants{
+		ID:                          e.ID,
+		MessageID:                   e.MessageID,
+		ChannelID:                   e.ChannelID,
+		CreatorID:                   e.CreatorID,
+		Title:                       e.Title,
+		Description:                 e.Description,
+		MaxSlots:                    e.MaxSlots,
+		ScheduledAt:                 e.ScheduledAt,
+		OrganizerValidationDMSentAt: e.OrganizerValidationDMSentAt,
+		OrganizerStep1FinalizedAt:   e.OrganizerStep1FinalizedAt,
+		Participants:                e.Participants,
+	}
+}
+
+func (h *Handler) HandleOrganizerFinalizeStep1(s *discordgo.Session, i *discordgo.InteractionCreate) {
+	ctx := context.Background()
+	customID := i.MessageComponentData().CustomID
+	prefix := "btn_organizer_finalize_"
+	if !strings.HasPrefix(customID, prefix) {
+		return
+	}
+	eventIDStr := strings.TrimPrefix(customID, prefix)
+	eventID, err := strconv.ParseUint(eventIDStr, 10, 32)
+	if err != nil {
+		return
+	}
+	userID := i.Member.User.ID
+	if i.User != nil {
+		userID = i.User.ID
+	}
+	err = h.eventUseCase.FinalizeOrganizerStep1(ctx, uint(eventID), userID)
+	if err != nil {
+		if errors.Is(err, domain.ErrNotOrganizer) {
+			content := "❌ Seul l'organisateur de cette sortie peut finaliser l'étape 1."
+			s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
+				Type: discordgo.InteractionResponseChannelMessageWithSource,
+				Data: &discordgo.InteractionResponseData{Content: content, Flags: discordgo.MessageFlagsEphemeral},
+			})
+		}
+		return
+	}
+	s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
+		Type: discordgo.InteractionResponseChannelMessageWithSource,
+		Data: &discordgo.InteractionResponseData{
+			Content: "✅ Étape 1 finalisée.",
+			Flags:   discordgo.MessageFlagsEphemeral,
+		},
+	})
+}
+
+func (h *Handler) HandleOrganizerAccept(s *discordgo.Session, i *discordgo.InteractionCreate) {
+	ctx := context.Background()
+	customID := i.MessageComponentData().CustomID
+	prefix := "btn_organizer_accept_"
+	if !strings.HasPrefix(customID, prefix) {
+		return
+	}
+	participantIDStr := strings.TrimPrefix(customID, prefix)
+	participantID, err := strconv.ParseUint(participantIDStr, 10, 32)
+	if err != nil {
+		return
+	}
+	participant, err := h.participantUseCase.GetParticipantByID(ctx, uint(participantID))
+	if err != nil {
+		return
+	}
+	event, err := h.eventUseCase.GetEventByID(ctx, participant.EventID)
+	if err != nil {
+		return
+	}
+	userID := i.Member.User.ID
+	if i.User != nil {
+		userID = i.User.ID
+	}
+	if event.CreatorID != userID {
+		s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
+			Type: discordgo.InteractionResponseChannelMessageWithSource,
+			Data: &discordgo.InteractionResponseData{
+				Content: "❌ Seul l'organisateur peut accepter ce potentiel intéressé.",
+				Flags:   discordgo.MessageFlagsEphemeral,
+			},
+		})
+		return
+	}
+	s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
+		Type: discordgo.InteractionResponseChannelMessageWithSource,
+		Data: &discordgo.InteractionResponseData{
+			Content: fmt.Sprintf("✅ %s a été accepté.", participant.Username),
+			Flags:   discordgo.MessageFlagsEphemeral,
+		},
+	})
+}
+
+func (h *Handler) HandleOrganizerRefuse(s *discordgo.Session, i *discordgo.InteractionCreate) {
+	ctx := context.Background()
+	customID := i.MessageComponentData().CustomID
+	prefix := "btn_organizer_refuse_"
+	if !strings.HasPrefix(customID, prefix) {
+		return
+	}
+	participantIDStr := strings.TrimPrefix(customID, prefix)
+	participantID, err := strconv.ParseUint(participantIDStr, 10, 32)
+	if err != nil {
+		return
+	}
+	userID := i.Member.User.ID
+	if i.User != nil {
+		userID = i.User.ID
+	}
+	participant, err := h.participantUseCase.RemoveParticipant(ctx, uint(participantID), userID)
+	if err != nil {
+		if errors.Is(err, domain.ErrNotOrganizer) {
+			s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
+				Type: discordgo.InteractionResponseChannelMessageWithSource,
+				Data: &discordgo.InteractionResponseData{
+					Content: "❌ Seul l'organisateur peut refuser ce potentiel intéressé.",
+					Flags:   discordgo.MessageFlagsEphemeral,
+				},
+			})
+		}
+		return
+	}
+	event, _ := h.eventUseCase.GetEventByID(ctx, participant.EventID)
+	if event != nil {
+		ch, _ := s.UserChannelCreate(participant.UserID)
+		if ch != nil {
+			s.ChannelMessageSend(ch.ID, fmt.Sprintf("L'organisateur de **%s** a refusé ton inscription.", event.Title))
+		}
+		h.updateEmbed(ctx, s, event.ChannelID, event.MessageID)
+	}
+	s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
+		Type: discordgo.InteractionResponseChannelMessageWithSource,
+		Data: &discordgo.InteractionResponseData{
+			Content: fmt.Sprintf("✅ %s a été refusé et retiré de la sortie.", participant.Username),
+			Flags:   discordgo.MessageFlagsEphemeral,
+		},
+	})
+}
+
+func (h *Handler) RunOrganizerValidationScheduler(s *discordgo.Session) {
+	ticker := time.NewTicker(10 * time.Minute)
+	defer ticker.Stop()
+	ctx := context.Background()
+	for range ticker.C {
+		now := time.Now()
+		events, err := h.eventUseCase.EventsNeedingH48OrganizerDM(ctx, now)
+		if err != nil {
+			log.Printf("❌ Scheduler H-48: %v", err)
+			continue
+		}
+		for _, e := range events {
+			eventFull, err := h.eventUseCase.GetEventByID(ctx, e.ID)
+			if err != nil || eventFull == nil {
+				continue
+			}
+			evWP := eventToEventWithParticipants(eventFull)
+			if err := h.sendOrganizerValidationDM(s, evWP); err != nil {
+				log.Printf("❌ Envoi MP H-48 organisateur (event %d): %v", e.ID, err)
+				continue
+			}
+			if err := h.eventUseCase.MarkOrganizerValidationDMSent(ctx, e.ID); err != nil {
+				log.Printf("❌ MarkOrganizerValidationDMSent (event %d): %v", e.ID, err)
+			}
+		}
+	}
+}

--- a/internal/adapters/discord/select_menu.go
+++ b/internal/adapters/discord/select_menu.go
@@ -166,7 +166,7 @@ func (h *Handler) HandleRemove(s *discordgo.Session, i *discordgo.InteractionCre
 	if event != nil {
 		luckyWinner, err := h.participantUseCase.GetNextWaitlistParticipant(ctx, event.ID)
 		if err == nil {
-			sendDM(s, luckyWinner.UserID, fmt.Sprintf("🎉 **Bonne nouvelle !** Une place s'est libérée pour **%s**, tu es maintenant inscrit !", event.Title))
+			sendDM(s, luckyWinner.UserID, fmt.Sprintf("🎉 **Bonne nouvelle !** Une place s'est libérée pour **%s**, tu es maintenant parmi les confirmés !", event.Title))
 		}
 		h.updateEmbed(ctx, s, event.ChannelID, event.MessageID)
 	}

--- a/internal/application/event.go
+++ b/internal/application/event.go
@@ -74,3 +74,22 @@ func (s *EventService) GetConfirmedParticipants(ctx context.Context, eventID uin
 func (s *EventService) GetEventsByCreatorID(ctx context.Context, creatorID string) ([]entities.Event, error) {
 	return s.eventRepo.FindByCreatorID(ctx, creatorID)
 }
+
+func (s *EventService) EventsNeedingH48OrganizerDM(ctx context.Context, now time.Time) ([]entities.Event, error) {
+	return s.eventRepo.FindEventsNeedingH48OrganizerDM(ctx, now)
+}
+
+func (s *EventService) MarkOrganizerValidationDMSent(ctx context.Context, eventID uint) error {
+	return s.eventRepo.MarkOrganizerValidationDMSent(ctx, eventID)
+}
+
+func (s *EventService) FinalizeOrganizerStep1(ctx context.Context, eventID uint, creatorID string) error {
+	event, err := s.eventRepo.FindByID(ctx, eventID)
+	if err != nil {
+		return domain.ErrEventNotFound
+	}
+	if event.CreatorID != creatorID {
+		return domain.ErrNotOrganizer
+	}
+	return s.eventRepo.MarkOrganizerStep1Finalized(ctx, eventID)
+}

--- a/internal/application/participant.go
+++ b/internal/application/participant.go
@@ -32,7 +32,7 @@ func (s *ParticipantService) JoinEvent(ctx context.Context, eventID uint, userID
 	}
 	existing, _ := s.participantRepo.FindByEventIDAndUserID(ctx, eventID, userID)
 	if existing != nil {
-		msg := "Tu es déjà inscrit !"
+		msg := "Tu as déjà manifesté ton intérêt."
 		if existing.Status == domain.StatusWaitlist {
 			msg = "Tu es en liste d'attente."
 		}
@@ -43,7 +43,7 @@ func (s *ParticipantService) JoinEvent(ctx context.Context, eventID uint, userID
 		return "", fmt.Errorf("count confirmed: %w", err)
 	}
 	status := domain.StatusConfirmed
-	reply := "✅ Tu es inscrit !"
+	reply := "✅ Ta demande est enregistrée !"
 	if event.MaxSlots > 0 && int(confirmedCount) >= event.MaxSlots {
 		status = domain.StatusWaitlist
 		reply = "⚠️ Complet ! Tu es en **liste d'attente**."
@@ -59,6 +59,14 @@ func (s *ParticipantService) JoinEvent(ctx context.Context, eventID uint, userID
 		return "", fmt.Errorf("create participant: %w", err)
 	}
 	return reply, nil
+}
+
+func (s *ParticipantService) GetParticipantByEventIDAndUserID(ctx context.Context, eventID uint, userID string) (*entities.Participant, error) {
+	return s.participantRepo.FindByEventIDAndUserID(ctx, eventID, userID)
+}
+
+func (s *ParticipantService) GetParticipantByID(ctx context.Context, id uint) (*entities.Participant, error) {
+	return s.participantRepo.FindByID(ctx, id)
 }
 
 func (s *ParticipantService) LeaveEvent(ctx context.Context, eventID uint, userID string) (bool, error) {

--- a/internal/domain/entities/event.go
+++ b/internal/domain/entities/event.go
@@ -3,17 +3,19 @@ package entities
 import "time"
 
 type Event struct {
-	ID                 uint
-	MessageID          string
-	ChannelID          string
-	CreatorID          string
-	Title              string
-	Description        string
-	MaxSlots           int
-	ScheduledAt        time.Time // zero = not set (for backward compat)
-	PrivateChannelID   string // salon privé organisateur seul (+ bot)
-	QuestionsThreadID  string // thread "Questions" dans ce salon
-	Participants       []Participant
-	CreatedAt          time.Time
-	UpdatedAt          time.Time
+	ID                          uint
+	MessageID                   string
+	ChannelID                   string
+	CreatorID                   string
+	Title                       string
+	Description                 string
+	MaxSlots                    int
+	ScheduledAt                 time.Time // zero = not set (for backward compat)
+	PrivateChannelID            string    // salon privé organisateur seul (+ bot)
+	QuestionsThreadID           string    // thread "Questions" dans ce salon
+	OrganizerValidationDMSentAt time.Time
+	OrganizerStep1FinalizedAt   time.Time
+	Participants                []Participant
+	CreatedAt                   time.Time
+	UpdatedAt                   time.Time
 }

--- a/internal/domain/errors.go
+++ b/internal/domain/errors.go
@@ -14,9 +14,3 @@ var (
 	ErrCannotReduceSlots       = errors.New("impossible de réduire le nombre de places")
 	ErrNotOrganizer            = errors.New("seul l'organisateur peut effectuer cette action")
 )
-
-// Participant status constants.
-const (
-	StatusConfirmed = "CONFIRMED"
-	StatusWaitlist  = "WAITLIST"
-)

--- a/internal/domain/status.go
+++ b/internal/domain/status.go
@@ -1,0 +1,6 @@
+package domain
+
+const (
+	StatusConfirmed = "CONFIRMED"
+	StatusWaitlist  = "WAITLIST"
+)

--- a/internal/infrastructure/database/event_repo.go
+++ b/internal/infrastructure/database/event_repo.go
@@ -3,6 +3,7 @@ package database
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/jackc/pgx/v5/pgtype"
 
@@ -92,6 +93,32 @@ func (r *EventRepository) FindByCreatorID(ctx context.Context, creatorID string)
 		out[i] = eventToDomain(rows[i])
 	}
 	return out, nil
+}
+
+func (r *EventRepository) FindEventsNeedingH48OrganizerDM(ctx context.Context, now time.Time) ([]entities.Event, error) {
+	rows, err := r.q.FindEventsNeedingH48OrganizerDM(ctx, pgtype.Timestamptz{Time: now, Valid: true})
+	if err != nil {
+		return nil, fmt.Errorf("find events needing H48 organizer DM: %w", err)
+	}
+	out := make([]entities.Event, len(rows))
+	for i := range rows {
+		out[i] = eventToDomain(rows[i])
+	}
+	return out, nil
+}
+
+func (r *EventRepository) MarkOrganizerValidationDMSent(ctx context.Context, eventID uint) error {
+	if err := r.q.MarkOrganizerValidationDMSent(ctx, int64(eventID)); err != nil {
+		return fmt.Errorf("mark organizer validation DM sent: %w", err)
+	}
+	return nil
+}
+
+func (r *EventRepository) MarkOrganizerStep1Finalized(ctx context.Context, eventID uint) error {
+	if err := r.q.MarkOrganizerStep1Finalized(ctx, int64(eventID)); err != nil {
+		return fmt.Errorf("mark organizer step1 finalized: %w", err)
+	}
+	return nil
 }
 
 func (r *EventRepository) Update(ctx context.Context, event *entities.Event) error {

--- a/internal/infrastructure/database/mapper.go
+++ b/internal/infrastructure/database/mapper.go
@@ -19,18 +19,20 @@ func pgtypeTimestamptzToTime(t pgtype.Timestamptz) time.Time {
 
 func eventToDomain(e sqlc_generated.Event) entities.Event {
 	return entities.Event{
-		ID:                uint(e.ID),
-		MessageID:         e.MessageID,
-		ChannelID:         e.ChannelID,
-		CreatorID:         e.CreatorID,
-		Title:             e.Title,
-		Description:       e.Description,
-		MaxSlots:          int(e.MaxSlots),
-		ScheduledAt:       pgtypeTimestamptzToTime(e.ScheduledAt),
-		PrivateChannelID:  e.PrivateChannelID,
-		QuestionsThreadID: e.QuestionsThreadID,
-		CreatedAt:         pgtypeTimestamptzToTime(e.CreatedAt),
-		UpdatedAt:         pgtypeTimestamptzToTime(e.UpdatedAt),
+		ID:                          uint(e.ID),
+		MessageID:                   e.MessageID,
+		ChannelID:                   e.ChannelID,
+		CreatorID:                   e.CreatorID,
+		Title:                       e.Title,
+		Description:                 e.Description,
+		MaxSlots:                    int(e.MaxSlots),
+		ScheduledAt:                 pgtypeTimestamptzToTime(e.ScheduledAt),
+		PrivateChannelID:            e.PrivateChannelID,
+		QuestionsThreadID:           e.QuestionsThreadID,
+		OrganizerValidationDMSentAt: pgtypeTimestamptzToTime(e.OrganizerValidationDmSentAt),
+		OrganizerStep1FinalizedAt:   pgtypeTimestamptzToTime(e.OrganizerStep1FinalizedAt),
+		CreatedAt:                   pgtypeTimestamptzToTime(e.CreatedAt),
+		UpdatedAt:                   pgtypeTimestamptzToTime(e.UpdatedAt),
 	}
 }
 

--- a/internal/infrastructure/database/sqlc_generated/models.go
+++ b/internal/infrastructure/database/sqlc_generated/models.go
@@ -9,18 +9,20 @@ import (
 )
 
 type Event struct {
-	ID                int64
-	MessageID         string
-	ChannelID         string
-	CreatorID         string
-	Title             string
-	Description       string
-	MaxSlots          int32
-	ScheduledAt       pgtype.Timestamptz
-	PrivateChannelID  string
-	QuestionsThreadID string
-	CreatedAt         pgtype.Timestamptz
-	UpdatedAt         pgtype.Timestamptz
+	ID                          int64
+	MessageID                   string
+	ChannelID                   string
+	CreatorID                   string
+	Title                       string
+	Description                 string
+	MaxSlots                    int32
+	ScheduledAt                 pgtype.Timestamptz
+	PrivateChannelID            string
+	QuestionsThreadID           string
+	OrganizerValidationDmSentAt pgtype.Timestamptz
+	OrganizerStep1FinalizedAt   pgtype.Timestamptz
+	CreatedAt                   pgtype.Timestamptz
+	UpdatedAt                   pgtype.Timestamptz
 }
 
 type Participant struct {

--- a/internal/ports/input/event.go
+++ b/internal/ports/input/event.go
@@ -2,6 +2,7 @@ package input
 
 import (
 	"context"
+	"time"
 
 	"servbot/internal/domain/entities"
 )
@@ -14,4 +15,7 @@ type EventUseCase interface {
 	GetWaitlistParticipants(ctx context.Context, eventID uint) ([]entities.Participant, error)
 	GetConfirmedParticipants(ctx context.Context, eventID uint) ([]entities.Participant, error)
 	GetEventsByCreatorID(ctx context.Context, creatorID string) ([]entities.Event, error)
+	EventsNeedingH48OrganizerDM(ctx context.Context, now time.Time) ([]entities.Event, error)
+	MarkOrganizerValidationDMSent(ctx context.Context, eventID uint) error
+	FinalizeOrganizerStep1(ctx context.Context, eventID uint, creatorID string) error
 }

--- a/internal/ports/input/participant.go
+++ b/internal/ports/input/participant.go
@@ -9,6 +9,8 @@ import (
 type ParticipantUseCase interface {
 	JoinEvent(ctx context.Context, eventID uint, userID, username string) (string, error)
 	LeaveEvent(ctx context.Context, eventID uint, userID string) (bool, error)
+	GetParticipantByEventIDAndUserID(ctx context.Context, eventID uint, userID string) (*entities.Participant, error)
+	GetParticipantByID(ctx context.Context, id uint) (*entities.Participant, error)
 	PromoteParticipant(ctx context.Context, participantID uint, creatorID string) (*entities.Participant, error)
 	RemoveParticipant(ctx context.Context, participantID uint, creatorID string) (*entities.Participant, error)
 	GetNextWaitlistParticipant(ctx context.Context, eventID uint) (*entities.Participant, error)

--- a/internal/ports/output/event_repo.go
+++ b/internal/ports/output/event_repo.go
@@ -2,6 +2,7 @@ package output
 
 import (
 	"context"
+	"time"
 
 	"servbot/internal/domain/entities"
 )
@@ -11,6 +12,9 @@ type EventRepository interface {
 	FindByMessageID(ctx context.Context, messageID string) (*entities.Event, error)
 	FindByID(ctx context.Context, id uint) (*entities.Event, error)
 	FindByCreatorID(ctx context.Context, creatorID string) ([]entities.Event, error)
+	FindEventsNeedingH48OrganizerDM(ctx context.Context, now time.Time) ([]entities.Event, error)
 	Update(ctx context.Context, event *entities.Event) error
+	MarkOrganizerValidationDMSent(ctx context.Context, eventID uint) error
+	MarkOrganizerStep1Finalized(ctx context.Context, eventID uint) error
 	Delete(ctx context.Context, id uint) error
 }

--- a/sqlc/queries/events.sql
+++ b/sqlc/queries/events.sql
@@ -3,6 +3,20 @@ INSERT INTO events (message_id, channel_id, creator_id, title, description, max_
 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
 RETURNING *;
 
+-- name: FindEventsNeedingH48OrganizerDM :many
+SELECT * FROM events
+WHERE scheduled_at IS NOT NULL
+  AND scheduled_at > $1
+  AND scheduled_at - interval '48 hours' <= $1
+  AND scheduled_at - interval '47 hours' > $1
+  AND organizer_validation_dm_sent_at IS NULL;
+
+-- name: MarkOrganizerValidationDMSent :exec
+UPDATE events SET organizer_validation_dm_sent_at = NOW(), updated_at = NOW() WHERE id = $1;
+
+-- name: MarkOrganizerStep1Finalized :exec
+UPDATE events SET organizer_step1_finalized_at = NOW(), updated_at = NOW() WHERE id = $1;
+
 -- name: GetEventByMessageID :one
 SELECT * FROM events WHERE message_id = $1;
 

--- a/sqlc/schema/001_events.sql
+++ b/sqlc/schema/001_events.sql
@@ -9,6 +9,8 @@ CREATE TABLE events (
     scheduled_at TIMESTAMPTZ,
     private_channel_id TEXT NOT NULL DEFAULT '',
     questions_thread_id TEXT NOT NULL DEFAULT '',
+    organizer_validation_dm_sent_at TIMESTAMPTZ,
+    organizer_step1_finalized_at TIMESTAMPTZ,
     created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
     updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
 );


### PR DESCRIPTION
Cas A (≥48h) : MP avec liste participants + bouton Finaliser l'étape 1
  - Si complet : envoi immédiat
  - Si non complet : envoi à H-48 via scheduler (ticker 10 min)
Cas B (<48h) : MP Accepter/Refuser à chaque nouvelle inscription
  - Refus : retrait participant + notification MP + maj embed
Handlers : btn_organizer_finalize, btn_organizer_accept, btn_organizer_refuse
Schema : ajout organizer_validation_dm_sent_at, organizer_step1_finalized_at