### PR TITLE
feat(BOT-24): finaliser étape 1 — MP validés, calendrier Discord

### DIFF
--- a/internal/adapters/discord/bot.go
+++ b/internal/adapters/discord/bot.go
@@ -101,11 +101,11 @@ func (b *Bot) handleMessageReactionAdd(s *discordgo.Session, r *discordgo.Messag
 	if r.Emoji.Name != reactionJoinEmoji || r.UserID == s.State.User.ID {
 		return
 	}
-	username := r.UserID
-	if r.Member != nil && r.Member.User != nil {
-		username = r.Member.User.Username
+	displayName := resolveDisplayName(r.Member)
+	if displayName == "" {
+		displayName = r.UserID
 	}
-	b.handler.HandleReactionJoin(s, r.ChannelID, r.MessageID, r.UserID, username)
+	b.handler.HandleReactionJoin(s, r.ChannelID, r.MessageID, r.UserID, displayName)
 }
 
 func (b *Bot) handleMessageReactionRemove(s *discordgo.Session, r *discordgo.MessageReactionRemove) {

--- a/internal/adapters/discord/event_message.go
+++ b/internal/adapters/discord/event_message.go
@@ -45,7 +45,8 @@ func (h *Handler) updateEmbed(ctx context.Context, s *discordgo.Session, channel
 	newEmbed := *origMsg.Embeds[0]
 	pkgdiscord.UpdateEventEmbed(&newEmbed, event, confirmedCount, waitlistCount)
 
-	components := h.buildComponents(messageID, waitlistCount, confirmedCount)
+	finalized := !event.OrganizerStep1FinalizedAt.IsZero()
+	components := h.buildComponents(messageID, waitlistCount, confirmedCount, finalized)
 
 	embeds := []*discordgo.MessageEmbed{&newEmbed}
 	if _, err := s.ChannelMessageEditComplex(&discordgo.MessageEdit{
@@ -58,9 +59,10 @@ func (h *Handler) updateEmbed(ctx context.Context, s *discordgo.Session, channel
 	}
 }
 
-func (h *Handler) buildComponents(messageID string, waitlistCount, confirmedCount int) []discordgo.MessageComponent {
-	rowComponents := []discordgo.MessageComponent{
-		discordgo.Button{Label: "✏️ Modifier la sortie", Style: discordgo.SecondaryButton, CustomID: fmt.Sprintf("btn_edit_event_%s", messageID)},
+func (h *Handler) buildComponents(messageID string, waitlistCount, confirmedCount int, finalized bool) []discordgo.MessageComponent {
+	var rowComponents []discordgo.MessageComponent
+	if !finalized {
+		rowComponents = append(rowComponents, discordgo.Button{Label: "✏️ Modifier la sortie", Style: discordgo.SecondaryButton, CustomID: fmt.Sprintf("btn_edit_event_%s", messageID)})
 	}
 	if waitlistCount > 0 {
 		rowComponents = append(rowComponents, discordgo.Button{Label: "⚙️ Gérer la liste d'attente", Style: discordgo.SecondaryButton, CustomID: fmt.Sprintf("btn_manage_waitlist_%s", messageID)})

--- a/internal/adapters/discord/modal.go
+++ b/internal/adapters/discord/modal.go
@@ -51,10 +51,7 @@ func (h *Handler) HandleModalSubmit(s *discordgo.Session, i *discordgo.Interacti
 	respondEphemeral(s, i.Interaction, "Création du post dans le forum...")
 
 	user := i.Member.User
-	displayName := user.Username
-	if i.Member.Nick != "" {
-		displayName = i.Member.Nick
-	}
+	displayName := resolveDisplayName(i.Member)
 	embed := pkgdiscord.BuildNewEventEmbed(user.ID, desc, scheduledAt, slots, displayName, user.AvatarURL("256"))
 
 	threadData := &discordgo.ThreadStart{
@@ -162,6 +159,10 @@ func (h *Handler) HandleEditEvent(s *discordgo.Session, i *discordgo.Interaction
 	}
 	if i.Member.User.ID != event.CreatorID {
 		respondEphemeral(s, i.Interaction, "❌ Seul l'organisateur peut modifier la sortie.")
+		return
+	}
+	if !event.OrganizerStep1FinalizedAt.IsZero() {
+		respondEphemeral(s, i.Interaction, "🔒 Cette sortie est verrouillée (étape 1 finalisée). Aucune modification n'est possible.")
 		return
 	}
 

--- a/internal/adapters/discord/reaction.go
+++ b/internal/adapters/discord/reaction.go
@@ -78,7 +78,6 @@ func (h *Handler) HandleReactionLeave(s *discordgo.Session, channelID, messageID
 	}
 	wasConfirmed, err := h.participantUseCase.LeaveEvent(ctx, event.ID, userID)
 	if err != nil {
-		sendDM(s, userID, "Tu ne faisais pas partie des intéressés.")
 		return
 	}
 	msg := "🗑️ Tu t'es désisté."

--- a/internal/adapters/discord/response.go
+++ b/internal/adapters/discord/response.go
@@ -4,6 +4,20 @@ import (
 	"github.com/bwmarrin/discordgo"
 )
 
+// Nick > GlobalName > Username
+func resolveDisplayName(member *discordgo.Member) string {
+	if member == nil || member.User == nil {
+		return ""
+	}
+	if member.Nick != "" {
+		return member.Nick
+	}
+	if member.User.GlobalName != "" {
+		return member.User.GlobalName
+	}
+	return member.User.Username
+}
+
 func respondEphemeral(s *discordgo.Session, i *discordgo.Interaction, content string) {
 	_ = s.InteractionRespond(i, &discordgo.InteractionResponse{
 		Type: discordgo.InteractionResponseChannelMessageWithSource,

--- a/internal/domain/errors.go
+++ b/internal/domain/errors.go
@@ -13,4 +13,5 @@ var (
 	ErrNoWaitlistParticipant   = errors.New("aucun participant en liste d'attente")
 	ErrCannotReduceSlots       = errors.New("impossible de réduire le nombre de places")
 	ErrNotOrganizer            = errors.New("seul l'organisateur peut effectuer cette action")
+	ErrEventAlreadyFinalized   = errors.New("cette sortie est déjà finalisée")
 )

--- a/internal/ports/input/event.go
+++ b/internal/ports/input/event.go
@@ -17,5 +17,5 @@ type EventUseCase interface {
 	GetEventsByCreatorID(ctx context.Context, creatorID string) ([]entities.Event, error)
 	EventsNeedingH48OrganizerDM(ctx context.Context, now time.Time) ([]entities.Event, error)
 	MarkOrganizerValidationDMSent(ctx context.Context, eventID uint) error
-	FinalizeOrganizerStep1(ctx context.Context, eventID uint, creatorID string) error
+	FinalizeOrganizerStep1(ctx context.Context, eventID uint, creatorID string) (*entities.Event, error)
 }


### PR DESCRIPTION
verouillage

- Envoie un MP de confirmation à tous les participants validés
- Crée un événement dans le calendrier Discord (Scheduled Events)
- Masque le bouton "Modifier" et bloque le modal après finalisation
- Ajoute ErrEventAlreadyFinalized pour l'idempotence
- Utilise resolveDisplayName (Nick > GlobalName > Username) partout
- Retire la réaction ✅ du participant refusé par l'organisateur
- Supprime le DM parasite sur retrait de réaction d'un non-inscrit