### PR TITLE
feat(BOT-25): manage private channel access for participants

### DIFF
--- a/internal/adapters/discord/modal.go
+++ b/internal/adapters/discord/modal.go
@@ -88,8 +88,6 @@ func (h *Handler) HandleModalSubmit(s *discordgo.Session, i *discordgo.Interacti
 	}
 	overwrites := []*discordgo.PermissionOverwrite{
 		{ID: guildID, Type: discordgo.PermissionOverwriteTypeRole, Deny: discordgo.PermissionViewChannel},
-		{ID: creatorID, Type: discordgo.PermissionOverwriteTypeMember, Allow: discordgo.PermissionViewChannel | discordgo.PermissionSendMessages},
-		{ID: botID, Type: discordgo.PermissionOverwriteTypeMember, Allow: discordgo.PermissionViewChannel | discordgo.PermissionSendMessages},
 	}
 	privChannelName := sanitizeChannelName(title)
 	if privChannelName == "" {
@@ -111,6 +109,8 @@ func (h *Handler) HandleModalSubmit(s *discordgo.Session, i *discordgo.Interacti
 		})
 		return
 	}
+	grantPrivateChannelAccess(s, privCh.ID, creatorID)
+	grantPrivateChannelAccess(s, privCh.ID, botID)
 
 	_, _ = s.ChannelMessageSend(privCh.ID, "💬 Salon privé pour cette sortie. Les questions des participants te seront relayées ici par le bot (thread **Questions**).")
 
@@ -161,7 +161,7 @@ func (h *Handler) HandleEditEvent(s *discordgo.Session, i *discordgo.Interaction
 		respondEphemeral(s, i.Interaction, "❌ Seul l'organisateur peut modifier la sortie.")
 		return
 	}
-	if !event.OrganizerStep1FinalizedAt.IsZero() {
+	if event.IsFinalized() {
 		respondEphemeral(s, i.Interaction, "🔒 Cette sortie est verrouillée (étape 1 finalisée). Aucune modification n'est possible.")
 		return
 	}

--- a/internal/application/event.go
+++ b/internal/application/event.go
@@ -91,7 +91,7 @@ func (s *EventService) FinalizeOrganizerStep1(ctx context.Context, eventID uint,
 	if event.CreatorID != creatorID {
 		return nil, domain.ErrNotOrganizer
 	}
-	if !event.OrganizerStep1FinalizedAt.IsZero() {
+	if event.IsFinalized() {
 		return nil, domain.ErrEventAlreadyFinalized
 	}
 	if err := s.eventRepo.MarkOrganizerStep1Finalized(ctx, eventID); err != nil {

--- a/internal/domain/entities/event.go
+++ b/internal/domain/entities/event.go
@@ -2,6 +2,10 @@ package entities
 
 import "time"
 
+func (e *Event) IsFinalized() bool {
+	return !e.OrganizerStep1FinalizedAt.IsZero()
+}
+
 type Event struct {
 	ID                          uint
 	MessageID                   string


### PR DESCRIPTION
- Added functions to grant and revoke access to private channels for users.
- Integrated access management into event handling, including participant acceptance and promotion from waitlist.
- Updated event finalization logic to utilize the new access control methods.
- Refactored existing code to improve clarity and maintainability.

This enhances the user experience by ensuring that only confirmed participants have access to private channels.