### PR TITLE
feat(BOT-26):  organizer kick participant

### DIFF
--- a/internal/adapters/discord/bot.go
+++ b/internal/adapters/discord/bot.go
@@ -57,6 +57,8 @@ func (b *Bot) handleInteraction(s *discordgo.Session, i *discordgo.InteractionCr
 			b.handler.HandleCommand(s, i)
 		case "sortie-template":
 			b.handler.HandleTemplateCommand(s, i)
+		case "retirer":
+			b.handler.HandleRemoveCommand(s, i)
 		}
 	case discordgo.InteractionModalSubmit:
 		modalData := i.ModalSubmitData()
@@ -90,8 +92,8 @@ func (b *Bot) handleInteraction(s *discordgo.Session, i *discordgo.InteractionCr
 			switch customID {
 			case "select_promote":
 				b.handler.HandlePromote(s, i)
-			case "select_remove":
-				b.handler.HandleRemove(s, i)
+			case "select_remove_user":
+				b.handler.HandleRemoveUserSelect(s, i)
 			}
 		}
 	}
@@ -150,6 +152,10 @@ func (b *Bot) Start() error {
 		{
 			Name:        "sortie-template",
 			Description: "Ouvrir le formulaire de sortie pré-rempli pour le debug",
+		},
+		{
+			Name:        "retirer",
+			Description: "Retirer un membre d'une sortie (à utiliser dans le salon privé)",
 		},
 	}
 

--- a/internal/adapters/discord/select_menu.go
+++ b/internal/adapters/discord/select_menu.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"servbot/internal/domain"
+	"servbot/internal/domain/entities"
 
 	"github.com/bwmarrin/discordgo"
 )
@@ -23,6 +24,8 @@ func parseParticipantID(value, prefix string) (uint, bool) {
 	}
 	return uint(id), true
 }
+
+// ── Waitlist (promote) ──────────────────────────────────────────────────────
 
 func (h *Handler) HandleManageWaitlist(s *discordgo.Session, i *discordgo.InteractionCreate) {
 	ctx := context.Background()
@@ -54,7 +57,12 @@ func (h *Handler) HandleManageWaitlist(s *discordgo.Session, i *discordgo.Intera
 		})
 	}
 
-	s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
+	if len(options) == 0 {
+		respondEphemeral(s, i.Interaction, "ℹ️ Il n'y a personne en liste d'attente.")
+		return
+	}
+
+	_ = s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
 		Type: discordgo.InteractionResponseChannelMessageWithSource,
 		Data: &discordgo.InteractionResponseData{
 			Content: "Choisissez une personne à promouvoir :",
@@ -62,7 +70,11 @@ func (h *Handler) HandleManageWaitlist(s *discordgo.Session, i *discordgo.Intera
 			Components: []discordgo.MessageComponent{
 				discordgo.ActionsRow{
 					Components: []discordgo.MessageComponent{
-						discordgo.SelectMenu{CustomID: "select_promote", Placeholder: "Sélectionner une personne à promouvoir", Options: options},
+						discordgo.SelectMenu{
+							CustomID:    "select_promote",
+							Placeholder: "Sélectionner une personne à promouvoir",
+							Options:     options,
+						},
 					},
 				},
 			},
@@ -100,6 +112,54 @@ func (h *Handler) HandlePromote(s *discordgo.Session, i *discordgo.InteractionCr
 	respondEphemeral(s, i.Interaction, fmt.Sprintf("✅ %s a été promu de la liste d'attente !", participant.Username))
 }
 
+// ── Remove participants ─────────────────────────────────────────────────────
+
+func (h *Handler) respondRemoveSelect(ctx context.Context, s *discordgo.Session, i *discordgo.InteractionCreate, event *entities.Event) {
+	confirmed, err := h.eventUseCase.GetConfirmedParticipants(ctx, event.ID)
+	if err != nil || len(confirmed) == 0 {
+		respondEphemeral(s, i.Interaction, "ℹ️ Il n'y a aucun participant confirmé à retirer.")
+		return
+	}
+
+	options := make([]discordgo.SelectMenuOption, 0, len(confirmed))
+	for _, p := range confirmed {
+		if p.UserID == event.CreatorID {
+			continue
+		}
+		options = append(options, discordgo.SelectMenuOption{
+			Label:       p.Username,
+			Value:       fmt.Sprintf("remove_%d", p.ID),
+			Description: fmt.Sprintf("Retirer %s de la sortie", p.Username),
+		})
+	}
+
+	if len(options) == 0 {
+		respondEphemeral(s, i.Interaction, "ℹ️ Il n'y a aucun participant à retirer.")
+		return
+	}
+
+	_ = s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
+		Type: discordgo.InteractionResponseChannelMessageWithSource,
+		Data: &discordgo.InteractionResponseData{
+			Content: "Sélectionne le(s) membre(s) à retirer de la sortie :",
+			Flags:   discordgo.MessageFlagsEphemeral,
+			Components: []discordgo.MessageComponent{
+				discordgo.ActionsRow{
+					Components: []discordgo.MessageComponent{
+						discordgo.SelectMenu{
+							CustomID:    "select_remove_user",
+							Placeholder: "Choisir un ou plusieurs membres",
+							Options:     options,
+							MaxValues:   len(options),
+						},
+					},
+				},
+			},
+		},
+	})
+}
+
+// HandleRemoveParticipant is triggered by the embed "Retirer" button.
 func (h *Handler) HandleRemoveParticipant(s *discordgo.Session, i *discordgo.InteractionCreate) {
 	ctx := context.Background()
 	event, err := h.eventUseCase.GetEventByMessageID(ctx, i.Message.ID)
@@ -112,64 +172,86 @@ func (h *Handler) HandleRemoveParticipant(s *discordgo.Session, i *discordgo.Int
 		return
 	}
 
-	confirmedParticipants, err := h.eventUseCase.GetConfirmedParticipants(ctx, event.ID)
-	if err != nil || len(confirmedParticipants) == 0 {
-		respondEphemeral(s, i.Interaction, "ℹ️ Il n'y a aucun participant confirmé à retirer.")
+	h.respondRemoveSelect(ctx, s, i, event)
+}
+
+// HandleRemoveCommand is triggered by the /retirer slash command from the private channel.
+func (h *Handler) HandleRemoveCommand(s *discordgo.Session, i *discordgo.InteractionCreate) {
+	ctx := context.Background()
+
+	event, err := h.eventUseCase.GetEventByPrivateChannelID(ctx, i.ChannelID)
+	if err != nil {
+		respondEphemeral(s, i.Interaction, "❌ Cette commande doit être utilisée dans le salon privé d'une sortie.")
 		return
 	}
 
-	options := make([]discordgo.SelectMenuOption, 0, len(confirmedParticipants))
-	for _, p := range confirmedParticipants {
-		if p.ID == 0 {
-			continue
-		}
-		options = append(options, discordgo.SelectMenuOption{
-			Label:       p.Username,
-			Value:       fmt.Sprintf("remove_%d", p.ID),
-			Description: fmt.Sprintf("Retirer %s de l'événement", p.Username),
-		})
+	if i.Member.User.ID != event.CreatorID {
+		respondEphemeral(s, i.Interaction, "❌ Seul l'organisateur peut retirer des participants.")
+		return
 	}
 
-	s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
-		Type: discordgo.InteractionResponseChannelMessageWithSource,
-		Data: &discordgo.InteractionResponseData{
-			Content: "Choisissez un participant à retirer :",
-			Flags:   discordgo.MessageFlagsEphemeral,
-			Components: []discordgo.MessageComponent{
-				discordgo.ActionsRow{
-					Components: []discordgo.MessageComponent{
-						discordgo.SelectMenu{CustomID: "select_remove", Placeholder: "Sélectionner un participant à retirer", Options: options},
-					},
-				},
-			},
-		},
-	})
+	h.respondRemoveSelect(ctx, s, i, event)
 }
 
-func (h *Handler) HandleRemove(s *discordgo.Session, i *discordgo.InteractionCreate) {
+// HandleRemoveUserSelect processes the remove select menu (shared by button and /retirer).
+func (h *Handler) HandleRemoveUserSelect(s *discordgo.Session, i *discordgo.InteractionCreate) {
 	ctx := context.Background()
 	data := i.MessageComponentData()
 	if len(data.Values) == 0 {
 		return
 	}
-	participantID, ok := parseParticipantID(data.Values[0], "remove_")
-	if !ok {
-		return
-	}
 
-	participant, err := h.participantUseCase.RemoveParticipant(ctx, participantID, i.Member.User.ID)
-	if err != nil {
-		if errors.Is(err, domain.ErrNotOrganizer) {
-			respondEphemeral(s, i.Interaction, "❌ Seul l'organisateur peut retirer des participants.")
+	var event *entities.Event
+	removed := make([]string, 0, len(data.Values))
+
+	for _, val := range data.Values {
+		pID, ok := parseParticipantID(val, "remove_")
+		if !ok {
+			continue
 		}
-		return
+
+		participant, err := h.participantUseCase.GetParticipantByID(ctx, pID)
+		if err != nil {
+			continue
+		}
+
+		// Resolve event once from the first valid participant.
+		if event == nil {
+			event, err = h.eventUseCase.GetEventByID(ctx, participant.EventID)
+			if err != nil {
+				respondEphemeral(s, i.Interaction, "❌ Événement non trouvé.")
+				return
+			}
+		}
+
+		wasConfirmed, err := h.participantUseCase.LeaveEvent(ctx, event.ID, participant.UserID)
+		if err != nil {
+			continue
+		}
+
+		_ = s.MessageReactionRemove(event.ChannelID, event.MessageID, reactionJoinEmoji, participant.UserID)
+		revokePrivateChannelAccess(s, event.PrivateChannelID, participant.UserID)
+
+		if wasConfirmed {
+			h.promoteNextFromWaitlist(s, ctx, event)
+		}
+
+		sendDM(s, participant.UserID, "🚪 Tu as été retiré de la sortie **"+event.Title+"** par l'organisateur.")
+		removed = append(removed, fmt.Sprintf("<@%s>", participant.UserID))
 	}
 
-	event, _ := h.eventUseCase.GetEventByID(ctx, participant.EventID)
 	if event != nil {
-		revokePrivateChannelAccess(s, event.PrivateChannelID, participant.UserID)
-		h.promoteNextFromWaitlist(s, ctx, event)
 		h.updateEmbed(ctx, s, event.ChannelID, event.MessageID)
 	}
-	respondEphemeral(s, i.Interaction, fmt.Sprintf("✅ %s a été retiré de l'événement.", participant.Username))
+
+	if len(removed) == 0 {
+		respondEphemeral(s, i.Interaction, "❌ Aucun participant n'a pu être retiré.")
+		return
+	}
+
+	msg := fmt.Sprintf("✅ %s a été retiré de la sortie.", removed[0])
+	if len(removed) > 1 {
+		msg = fmt.Sprintf("✅ %d participants retirés : %s", len(removed), strings.Join(removed, ", "))
+	}
+	respondEphemeral(s, i.Interaction, msg)
 }

--- a/internal/application/event.go
+++ b/internal/application/event.go
@@ -52,6 +52,10 @@ func (s *EventService) GetEventByID(ctx context.Context, id uint) (*entities.Eve
 	return s.eventRepo.FindByID(ctx, id)
 }
 
+func (s *EventService) GetEventByPrivateChannelID(ctx context.Context, privateChannelID string) (*entities.Event, error) {
+	return s.eventRepo.FindByPrivateChannelID(ctx, privateChannelID)
+}
+
 func (s *EventService) UpdateEvent(ctx context.Context, event *entities.Event) error {
 	confirmedCount, err := s.participantRepo.CountByEventIDAndStatus(ctx, event.ID, domain.StatusConfirmed)
 	if err != nil {

--- a/internal/infrastructure/database/event_repo.go
+++ b/internal/infrastructure/database/event_repo.go
@@ -71,6 +71,18 @@ func (r *EventRepository) FindByID(ctx context.Context, id uint) (*entities.Even
 	return &e, nil
 }
 
+func (r *EventRepository) FindByPrivateChannelID(ctx context.Context, privateChannelID string) (*entities.Event, error) {
+	row, err := r.q.GetEventByPrivateChannelID(ctx, privateChannelID)
+	if err != nil {
+		return nil, fmt.Errorf("get event by private channel id: %w", err)
+	}
+	e := eventToDomain(row)
+	if err := r.attachParticipants(ctx, &e); err != nil {
+		return nil, err
+	}
+	return &e, nil
+}
+
 func (r *EventRepository) attachParticipants(ctx context.Context, e *entities.Event) error {
 	participants, err := r.q.GetParticipantsByEventID(ctx, int64(e.ID))
 	if err != nil {

--- a/internal/infrastructure/database/sqlc_generated/events.sql.go
+++ b/internal/infrastructure/database/sqlc_generated/events.sql.go
@@ -166,6 +166,32 @@ func (q *Queries) GetEventByMessageID(ctx context.Context, messageID string) (Ev
 	return i, err
 }
 
+const getEventByPrivateChannelID = `-- name: GetEventByPrivateChannelID :one
+SELECT id, message_id, channel_id, creator_id, title, description, max_slots, scheduled_at, private_channel_id, questions_thread_id, organizer_validation_dm_sent_at, organizer_step1_finalized_at, created_at, updated_at FROM events WHERE private_channel_id = $1
+`
+
+func (q *Queries) GetEventByPrivateChannelID(ctx context.Context, privateChannelID string) (Event, error) {
+	row := q.db.QueryRow(ctx, getEventByPrivateChannelID, privateChannelID)
+	var i Event
+	err := row.Scan(
+		&i.ID,
+		&i.MessageID,
+		&i.ChannelID,
+		&i.CreatorID,
+		&i.Title,
+		&i.Description,
+		&i.MaxSlots,
+		&i.ScheduledAt,
+		&i.PrivateChannelID,
+		&i.QuestionsThreadID,
+		&i.OrganizerValidationDmSentAt,
+		&i.OrganizerStep1FinalizedAt,
+		&i.CreatedAt,
+		&i.UpdatedAt,
+	)
+	return i, err
+}
+
 const getEventsByCreatorID = `-- name: GetEventsByCreatorID :many
 SELECT id, message_id, channel_id, creator_id, title, description, max_slots, scheduled_at, private_channel_id, questions_thread_id, organizer_validation_dm_sent_at, organizer_step1_finalized_at, created_at, updated_at FROM events WHERE creator_id = $1 ORDER BY created_at DESC
 `

--- a/internal/ports/input/event.go
+++ b/internal/ports/input/event.go
@@ -11,6 +11,7 @@ type EventUseCase interface {
 	CreateEvent(ctx context.Context, event *entities.Event, creatorUsername string) error
 	GetEventByMessageID(ctx context.Context, messageID string) (*entities.Event, error)
 	GetEventByID(ctx context.Context, id uint) (*entities.Event, error)
+	GetEventByPrivateChannelID(ctx context.Context, privateChannelID string) (*entities.Event, error)
 	UpdateEvent(ctx context.Context, event *entities.Event) error
 	GetWaitlistParticipants(ctx context.Context, eventID uint) ([]entities.Participant, error)
 	GetConfirmedParticipants(ctx context.Context, eventID uint) ([]entities.Participant, error)

--- a/internal/ports/output/event_repo.go
+++ b/internal/ports/output/event_repo.go
@@ -11,6 +11,7 @@ type EventRepository interface {
 	Create(ctx context.Context, event *entities.Event) error
 	FindByMessageID(ctx context.Context, messageID string) (*entities.Event, error)
 	FindByID(ctx context.Context, id uint) (*entities.Event, error)
+	FindByPrivateChannelID(ctx context.Context, privateChannelID string) (*entities.Event, error)
 	FindByCreatorID(ctx context.Context, creatorID string) ([]entities.Event, error)
 	FindEventsNeedingH48OrganizerDM(ctx context.Context, now time.Time) ([]entities.Event, error)
 	Update(ctx context.Context, event *entities.Event) error

--- a/sqlc/queries/events.sql
+++ b/sqlc/queries/events.sql
@@ -35,5 +35,8 @@ UPDATE events SET
     updated_at = NOW()
 WHERE id = $1;
 
+-- name: GetEventByPrivateChannelID :one
+SELECT * FROM events WHERE private_channel_id = $1;
+
 -- name: DeleteEvent :exec
 DELETE FROM events WHERE id = $1;


### PR DESCRIPTION
## Summary
- Grant private channel access to confirmed participants at finalization (step 1)
- Revoke access on desistment (✅ removal) or organizer kick
- Promote next waitlisted participant and grant access when a spot opens
- Add `/retirer` command + embed "Retirer" button for organizer to remove participants
- Remove ✅ reaction, update lists, send DM on removal
- Centralize `grantPrivateChannelAccess` / `revokePrivateChannelAccess`

Closes #9 