### PR TITLE
feat(BOT-28): add question handling modals and event interaction buttons

### DIFF
--- a/internal/adapters/discord/bot.go
+++ b/internal/adapters/discord/bot.go
@@ -81,6 +81,10 @@ func (b *Bot) handleInteraction(s *discordgo.Session, i *discordgo.InteractionCr
 			}
 		} else if strings.HasPrefix(customID, "btn_") {
 			switch {
+			case strings.HasPrefix(customID, "btn_ask_question_"):
+				b.handler.HandleAskQuestion(s, i)
+			case strings.HasPrefix(customID, "btn_answer_question_"):
+				b.handler.HandleAnswerQuestion(s, i)
 			case strings.HasPrefix(customID, "btn_manage_waitlist_"):
 				b.handler.HandleManageWaitlist(s, i)
 			case strings.HasPrefix(customID, "btn_remove_participant_"):

--- a/internal/adapters/discord/event_message.go
+++ b/internal/adapters/discord/event_message.go
@@ -84,6 +84,11 @@ func (h *Handler) buildComponents(messageID string, waitlistCount, confirmedCoun
 	if !editLocked {
 		rowComponents = append(rowComponents, discordgo.Button{Label: "✏️ Modifier la sortie", Style: discordgo.SecondaryButton, CustomID: fmt.Sprintf("btn_edit_event_%s", messageID)})
 	}
+	rowComponents = append(rowComponents, discordgo.Button{
+		Label:    "❓ Poser une question",
+		Style:    discordgo.SecondaryButton,
+		CustomID: fmt.Sprintf("btn_ask_question_%s", messageID),
+	})
 	if waitlistCount > 0 {
 		rowComponents = append(rowComponents, discordgo.Button{Label: "⚙️ Gérer la liste d'attente", Style: discordgo.SecondaryButton, CustomID: fmt.Sprintf("btn_manage_waitlist_%s", messageID)})
 	}

--- a/internal/adapters/discord/modal_event_create.go
+++ b/internal/adapters/discord/modal_event_create.go
@@ -1,0 +1,150 @@
+package discord
+
+import (
+	"context"
+	"errors"
+	"log"
+	"strconv"
+
+	"servbot/internal/domain/entities"
+	pkgdiscord "servbot/pkg/discord"
+
+	"github.com/bwmarrin/discordgo"
+)
+
+// parseSlots convertit la valeur du champ "Nombre de places" en entier
+// (0 ou vide = illimité).
+func parseSlots(slotsStr string) (int, error) {
+	if slotsStr == "" || slotsStr == "0" {
+		return 0, nil
+	}
+	n, err := strconv.Atoi(slotsStr)
+	if err != nil {
+		return 0, err
+	}
+	if n < 0 {
+		return 0, errors.New("invalid")
+	}
+	return n, nil
+}
+
+// handleCreateEventModalSubmit gère la soumission du modal de création de sortie.
+func (h *Handler) handleCreateEventModalSubmit(s *discordgo.Session, i *discordgo.InteractionCreate, data discordgo.ModalSubmitInteractionData) {
+	title, desc, dateStr, timeStr, slotsStr := pkgdiscord.ExtractModalData(data)
+
+	if dateStr == "" || timeStr == "" {
+		respondEphemeral(s, i.Interaction, "❌ Date et heure requises (JJ/MM/AAAA et HH:MM).")
+		return
+	}
+	scheduledAt, err := pkgdiscord.ParseEventDateTime(dateStr, timeStr)
+	if err != nil {
+		respondEphemeral(s, i.Interaction, "❌ "+err.Error())
+		return
+	}
+	slots, err := parseSlots(slotsStr)
+	if err != nil {
+		respondEphemeral(s, i.Interaction, "❌ Nombre de places invalide (positif ou vide).")
+		return
+	}
+
+	respondEphemeral(s, i.Interaction, "Création du post dans le forum...")
+
+	user := i.Member.User
+	displayName := resolveDisplayName(i.Member)
+	embed := pkgdiscord.BuildNewEventEmbed(user.ID, desc, scheduledAt, slots, displayName, user.AvatarURL("256"))
+
+	threadData := &discordgo.ThreadStart{
+		Name:                title,
+		AutoArchiveDuration: 1440,
+		Type:                discordgo.ChannelTypeGuildPublicThread,
+	}
+	messageData := &discordgo.MessageSend{
+		Embeds: []*discordgo.MessageEmbed{embed},
+	}
+
+	thread, err := s.ForumThreadStartComplex(h.forumChannelID, threadData, messageData)
+	if err != nil {
+		log.Println("❌ Erreur création forum post:", err)
+		s.FollowupMessageCreate(i.Interaction, true, &discordgo.WebhookParams{
+			Content: "Erreur lors de la création du post (Vérifie que le Bot a la permission 'Créer des messages publics' et 'Créer des fils').",
+		})
+		return
+	}
+
+	message, err := s.ChannelMessage(thread.ID, thread.ID)
+	msgID := thread.ID
+	if err == nil && message != nil {
+		msgID = message.ID
+	}
+
+	creatorID := i.Member.User.ID
+	guildID := i.GuildID
+	botID := s.State.User.ID
+
+	parentID := ""
+	if ch, err := s.Channel(h.forumChannelID); err == nil && ch != nil && ch.ParentID != "" {
+		parentID = ch.ParentID
+	}
+	overwrites := []*discordgo.PermissionOverwrite{
+		{ID: guildID, Type: discordgo.PermissionOverwriteTypeRole, Deny: discordgo.PermissionViewChannel},
+	}
+	privChannelName := sanitizeChannelName(title)
+	if privChannelName == "" {
+		privChannelName = "sortie"
+	}
+	privData := discordgo.GuildChannelCreateData{
+		Name:                 privChannelName,
+		Type:                 discordgo.ChannelTypeGuildText,
+		PermissionOverwrites: overwrites,
+	}
+	if parentID != "" {
+		privData.ParentID = parentID
+	}
+	privCh, err := s.GuildChannelCreateComplex(guildID, privData)
+	if err != nil {
+		log.Printf("❌ Création salon privé sortie: %v", err)
+		s.FollowupMessageCreate(i.Interaction, true, &discordgo.WebhookParams{
+			Content: "❌ Post forum créé mais erreur lors de la création du salon privé. Vérifie les permissions du bot (Gérer les salons).",
+		})
+		return
+	}
+	grantPrivateChannelAccess(s, privCh.ID, creatorID)
+	grantPrivateChannelAccess(s, privCh.ID, botID)
+
+	_, _ = s.ChannelMessageSend(privCh.ID, "💬 Salon privé pour cette sortie. Les questions des participants te seront relayées ici par le bot (thread **Questions**).")
+
+	questionsThreadID := ""
+	questionsThread, threadErr := s.ThreadStart(privCh.ID, "Questions", discordgo.ChannelTypeGuildPrivateThread, 1440)
+	if threadErr != nil {
+		log.Printf("❌ Création thread privé Questions: %v", threadErr)
+	} else {
+		questionsThreadID = questionsThread.ID
+		_ = s.ThreadMemberAdd(questionsThread.ID, creatorID)
+		_ = s.ThreadMemberAdd(questionsThread.ID, botID)
+		_, _ = s.ChannelMessageSend(questionsThread.ID, "Les questions des participants te seront relayées ici par le bot.")
+	}
+
+	event := &entities.Event{
+		MessageID:         msgID,
+		ChannelID:         thread.ID,
+		CreatorID:         creatorID,
+		Title:             title,
+		Description:       desc,
+		MaxSlots:          slots,
+		ScheduledAt:       scheduledAt,
+		PrivateChannelID:  privCh.ID,
+		QuestionsThreadID: questionsThreadID,
+	}
+
+	ctx := context.Background()
+	if err := h.eventUseCase.CreateEvent(ctx, event, displayName); err != nil {
+		log.Printf("❌ Erreur lors de la sauvegarde de l'événement: %v", err)
+		s.FollowupMessageCreate(i.Interaction, true, &discordgo.WebhookParams{
+			Content: "❌ Erreur lors de la sauvegarde de l'événement.",
+		})
+		return
+	}
+
+	h.updateEmbed(ctx, s, event.ChannelID, event.MessageID)
+	_ = s.MessageReactionAdd(event.ChannelID, event.MessageID, "✅")
+}

--- a/internal/adapters/discord/modal_questions.go
+++ b/internal/adapters/discord/modal_questions.go
@@ -1,0 +1,289 @@
+package discord
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"strconv"
+	"strings"
+
+	"github.com/bwmarrin/discordgo"
+)
+
+// HandleAskQuestion ouvre le modal "Ta question" quand un membre (non orga) clique sur le bouton du post forum.
+func (h *Handler) HandleAskQuestion(s *discordgo.Session, i *discordgo.InteractionCreate) {
+	ctx := context.Background()
+	event, err := h.eventUseCase.GetEventByMessageID(ctx, i.Message.ID)
+	if err != nil || event == nil {
+		respondEphemeral(s, i.Interaction, "❌ Impossible de retrouver la sortie pour cette question.")
+		return
+	}
+	if event.QuestionsThreadID == "" {
+		respondEphemeral(s, i.Interaction, "❌ Le thread privé des questions n'est pas disponible pour cette sortie.")
+		return
+	}
+	userID := interactionUserID(i)
+	if userID == event.CreatorID {
+		respondEphemeral(s, i.Interaction, "En tant qu'organisateur, tu reçois les questions dans le thread **Questions** du salon privé ; inutile de t'en poser une.")
+		return
+	}
+
+	customID := fmt.Sprintf("ask_question_modal_%d", event.ID)
+	_ = s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
+		Type: discordgo.InteractionResponseModal,
+		Data: &discordgo.InteractionResponseData{
+			CustomID: customID,
+			Title:    "Poser une question",
+			Components: []discordgo.MessageComponent{
+				discordgo.ActionsRow{
+					Components: []discordgo.MessageComponent{
+						discordgo.TextInput{
+							CustomID:    "question",
+							Label:       "Ta question",
+							Style:       discordgo.TextInputParagraph,
+							Required:    true,
+							Placeholder: "Ex: Où se retrouve-t-on exactement ?",
+						},
+					},
+				},
+			},
+		},
+	})
+}
+
+// HandleAnswerQuestion ouvre le modal "Ta réponse" quand l'organisateur clique sur Répondre dans le thread Questions.
+func (h *Handler) HandleAnswerQuestion(s *discordgo.Session, i *discordgo.InteractionCreate) {
+	customID := i.MessageComponentData().CustomID
+	prefix := "btn_answer_question_"
+	if !strings.HasPrefix(customID, prefix) {
+		return
+	}
+	payload := strings.TrimPrefix(customID, prefix)
+	parts := strings.Split(payload, "_")
+	if len(parts) < 2 {
+		return
+	}
+	eventIDStr, memberID := parts[0], parts[1]
+	questionMessageID := ""
+	if len(parts) >= 3 {
+		questionMessageID = parts[2]
+	}
+	if eventIDStr == "" || memberID == "" {
+		return
+	}
+
+	eventID, err := strconv.ParseUint(eventIDStr, 10, 32)
+	if err != nil {
+		return
+	}
+
+	ctx := context.Background()
+	event, err := h.eventUseCase.GetEventByID(ctx, uint(eventID))
+	if err != nil || event == nil {
+		respondEphemeral(s, i.Interaction, "❌ Impossible de retrouver la sortie pour cette réponse.")
+		return
+	}
+	userID := interactionUserID(i)
+	if userID == "" || userID != event.CreatorID {
+		respondEphemeral(s, i.Interaction, "❌ Seul l'organisateur peut répondre à cette question.")
+		return
+	}
+
+	modalID := fmt.Sprintf("answer_question_modal_%d_%s", event.ID, memberID)
+	if questionMessageID != "" {
+		modalID += "_" + questionMessageID
+	}
+	_ = s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
+		Type: discordgo.InteractionResponseModal,
+		Data: &discordgo.InteractionResponseData{
+			CustomID: modalID,
+			Title:    "Ta réponse",
+			Components: []discordgo.MessageComponent{
+				discordgo.ActionsRow{
+					Components: []discordgo.MessageComponent{
+						discordgo.TextInput{
+							CustomID:    "answer",
+							Label:       "Ta réponse",
+							Style:       discordgo.TextInputParagraph,
+							Required:    true,
+							Placeholder: "Ta réponse sera envoyée en MP au membre.",
+						},
+					},
+				},
+			},
+		},
+	})
+}
+
+func extractTextInputValue(data discordgo.ModalSubmitInteractionData, id string) string {
+	for _, comp := range data.Components {
+		if row, ok := comp.(*discordgo.ActionsRow); ok {
+			for _, inner := range row.Components {
+				if input, ok := inner.(*discordgo.TextInput); ok && input.CustomID == id {
+					return input.Value
+				}
+			}
+		}
+	}
+	return ""
+}
+
+// handleAskQuestionModalSubmit reçoit la question, la poste dans le thread Questions et ajoute un bouton Répondre.
+func (h *Handler) handleAskQuestionModalSubmit(s *discordgo.Session, i *discordgo.InteractionCreate, data discordgo.ModalSubmitInteractionData) {
+	customID := data.CustomID
+	prefix := "ask_question_modal_"
+	if !strings.HasPrefix(customID, prefix) {
+		return
+	}
+	eventIDStr := strings.TrimPrefix(customID, prefix)
+	eventID, err := strconv.ParseUint(eventIDStr, 10, 32)
+	if err != nil {
+		respondEphemeral(s, i.Interaction, "❌ Identifiant de sortie invalide pour la question.")
+		return
+	}
+
+	question := extractTextInputValue(data, "question")
+	question = strings.TrimSpace(question)
+	if question == "" {
+		respondEphemeral(s, i.Interaction, "❌ Merci de saisir une question.")
+		return
+	}
+
+	ctx := context.Background()
+	event, err := h.eventUseCase.GetEventByID(ctx, uint(eventID))
+	if err != nil || event == nil {
+		respondEphemeral(s, i.Interaction, "❌ Impossible de retrouver la sortie pour cette question.")
+		return
+	}
+	if event.QuestionsThreadID == "" {
+		respondEphemeral(s, i.Interaction, "❌ Le thread privé des questions n'est pas disponible pour cette sortie.")
+		return
+	}
+
+	memberID := interactionUserID(i)
+	if memberID == "" {
+		respondEphemeral(s, i.Interaction, "❌ Impossible d'identifier le membre qui pose la question.")
+		return
+	}
+
+	displayName := ""
+	if i.Member != nil {
+		displayName = resolveDisplayName(i.Member)
+	}
+	if displayName == "" {
+		displayName = memberID
+	}
+
+	var contentBuilder strings.Builder
+	contentBuilder.WriteString(fmt.Sprintf("<@%s> te demande :\n", memberID))
+	contentBuilder.WriteString(fmt.Sprintf("> %s\n", question))
+	contentStr := contentBuilder.String()
+
+	msg, err := s.ChannelMessageSend(event.QuestionsThreadID, contentStr)
+	if err != nil || msg == nil {
+		respondEphemeral(s, i.Interaction, "❌ Impossible d'envoyer la question à l'organisateur.")
+		return
+	}
+	components := []discordgo.MessageComponent{
+		discordgo.ActionsRow{
+			Components: []discordgo.MessageComponent{
+				discordgo.Button{
+					Label:    "Répondre",
+					Style:    discordgo.PrimaryButton,
+					CustomID: fmt.Sprintf("btn_answer_question_%d_%s_%s", event.ID, memberID, msg.ID),
+				},
+			},
+		},
+	}
+	_, err = s.ChannelMessageEditComplex(&discordgo.MessageEdit{
+		ID:         msg.ID,
+		Channel:    event.QuestionsThreadID,
+		Content:    &contentStr,
+		Components: &components,
+	})
+	if err != nil {
+		log.Printf("❌ Ajout bouton Répondre (question thread): %v", err)
+	}
+
+	respondEphemeral(s, i.Interaction, "✅ Ta question a été envoyée à l'organisateur.")
+}
+
+// extractQuestionFromThreadMessage extrait le texte de la question depuis le message posté dans le thread (format: "<@id> te demande :\n> question").
+func extractQuestionFromThreadMessage(content string) string {
+	const prefix = "te demande :\n"
+	idx := strings.Index(content, prefix)
+	if idx == -1 {
+		return ""
+	}
+	block := strings.TrimSpace(content[idx+len(prefix):])
+	// Enlever le préfixe "> " de chaque ligne (citation Discord)
+	block = strings.TrimPrefix(block, "> ")
+	block = strings.ReplaceAll(block, "\n> ", "\n")
+	return strings.TrimSpace(block)
+}
+
+// handleAnswerQuestionModalSubmit envoie la réponse en MP au membre, précédée de sa question.
+func (h *Handler) handleAnswerQuestionModalSubmit(s *discordgo.Session, i *discordgo.InteractionCreate, data discordgo.ModalSubmitInteractionData) {
+	customID := data.CustomID
+	prefix := "answer_question_modal_"
+	if !strings.HasPrefix(customID, prefix) {
+		return
+	}
+	payload := strings.TrimPrefix(customID, prefix)
+	parts := strings.Split(payload, "_")
+	if len(parts) < 2 {
+		respondEphemeral(s, i.Interaction, "❌ Données de réponse invalides.")
+		return
+	}
+	eventIDStr, memberID := parts[0], parts[1]
+	questionMessageID := ""
+	if len(parts) >= 3 {
+		questionMessageID = parts[2]
+	}
+	eventID, err := strconv.ParseUint(eventIDStr, 10, 32)
+	if err != nil {
+		respondEphemeral(s, i.Interaction, "❌ Identifiant de sortie invalide pour la réponse.")
+		return
+	}
+
+	answer := extractTextInputValue(data, "answer")
+	answer = strings.TrimSpace(answer)
+	if answer == "" {
+		respondEphemeral(s, i.Interaction, "❌ Merci de saisir une réponse.")
+		return
+	}
+
+	ctx := context.Background()
+	event, err := h.eventUseCase.GetEventByID(ctx, uint(eventID))
+	if err != nil || event == nil {
+		respondEphemeral(s, i.Interaction, "❌ Impossible de retrouver la sortie pour cette réponse.")
+		return
+	}
+	userID := interactionUserID(i)
+	if userID == "" || userID != event.CreatorID {
+		respondEphemeral(s, i.Interaction, "❌ Seul l'organisateur peut répondre à cette question.")
+		return
+	}
+
+	questionText := ""
+	if event.QuestionsThreadID != "" && questionMessageID != "" {
+		if qMsg, err := s.ChannelMessage(event.QuestionsThreadID, questionMessageID); err == nil && qMsg != nil {
+			questionText = extractQuestionFromThreadMessage(qMsg.Content)
+		}
+	}
+
+	var dmBuilder strings.Builder
+	if link := h.messageLink(event.ChannelID, event.MessageID); link != "" {
+		dmBuilder.WriteString(fmt.Sprintf("✉️ **[%s](%s)** – Réponse de l'organisateur\n\n", event.Title, link))
+	} else {
+		dmBuilder.WriteString(fmt.Sprintf("✉️ **%s** – Réponse de l'organisateur\n\n", event.Title))
+	}
+	if questionText != "" {
+		dmBuilder.WriteString(fmt.Sprintf("**Ta question :**\n%s\n\n", questionText))
+	}
+	dmBuilder.WriteString("**Réponse :**\n")
+	dmBuilder.WriteString(answer)
+
+	sendDM(s, memberID, dmBuilder.String())
+	respondEphemeral(s, i.Interaction, "✅ Réponse envoyée en MP au membre.")
+}

--- a/internal/adapters/discord/modal_router.go
+++ b/internal/adapters/discord/modal_router.go
@@ -1,0 +1,22 @@
+package discord
+
+import (
+	"strings"
+
+	"github.com/bwmarrin/discordgo"
+)
+
+// HandleModalSubmit route les différents modals en fonction de leur CustomID.
+func (h *Handler) HandleModalSubmit(s *discordgo.Session, i *discordgo.InteractionCreate) {
+	data := i.ModalSubmitData()
+	switch {
+	case data.CustomID == "create_event_modal":
+		h.handleCreateEventModalSubmit(s, i, data)
+	case strings.HasPrefix(data.CustomID, "ask_question_modal_"):
+		h.handleAskQuestionModalSubmit(s, i, data)
+	case strings.HasPrefix(data.CustomID, "answer_question_modal_"):
+		h.handleAnswerQuestionModalSubmit(s, i, data)
+	default:
+		// Modal inconnu : on ignore silencieusement pour rester robuste.
+	}
+}


### PR DESCRIPTION
- Implemented modals for asking and answering questions related to events.
- Added buttons for users to ask questions and for organizers to respond within the Discord bot.
- Enhanced event management by routing modal submissions appropriately.

This update improves user engagement and interaction during events, allowing for better communication between participants and organizers.