### PR TITLE
feat(BOT-29): enhance participant promotion and waitlist management

### DIFF
--- a/internal/adapters/discord/bot.go
+++ b/internal/adapters/discord/bot.go
@@ -93,11 +93,11 @@ func (b *Bot) handleInteraction(s *discordgo.Session, i *discordgo.InteractionCr
 				b.handler.HandleEditEvent(s, i)
 			}
 		} else {
-			switch customID {
-			case "select_promote":
-				b.handler.HandlePromote(s, i)
-			case "select_remove_user":
+			switch {
+			case customID == "select_remove_user":
 				b.handler.HandleRemoveUserSelect(s, i)
+			case strings.HasPrefix(customID, "select_promote"):
+				b.handler.HandlePromote(s, i)
 			}
 		}
 	}

--- a/internal/adapters/discord/event_message.go
+++ b/internal/adapters/discord/event_message.go
@@ -79,25 +79,28 @@ func (h *Handler) updateEmbed(ctx context.Context, s *discordgo.Session, channel
 	}
 }
 
+const buttonsPerRow = 2
+
 func (h *Handler) buildComponents(messageID string, waitlistCount, confirmedCount int, editLocked bool) []discordgo.MessageComponent {
-	var rowComponents []discordgo.MessageComponent
+	var buttons []discordgo.MessageComponent
 	if !editLocked {
-		rowComponents = append(rowComponents, discordgo.Button{Label: "✏️ Modifier la sortie", Style: discordgo.SecondaryButton, CustomID: fmt.Sprintf("btn_edit_event_%s", messageID)})
+		buttons = append(buttons, discordgo.Button{Label: "✏️ Modifier la sortie", Style: discordgo.SecondaryButton, CustomID: fmt.Sprintf("btn_edit_event_%s", messageID)})
 	}
-	rowComponents = append(rowComponents, discordgo.Button{
+	buttons = append(buttons, discordgo.Button{
 		Label:    "❓ Poser une question",
 		Style:    discordgo.SecondaryButton,
 		CustomID: fmt.Sprintf("btn_ask_question_%s", messageID),
 	})
 	if waitlistCount > 0 {
-		rowComponents = append(rowComponents, discordgo.Button{Label: "⚙️ Gérer la liste d'attente", Style: discordgo.SecondaryButton, CustomID: fmt.Sprintf("btn_manage_waitlist_%s", messageID)})
+		buttons = append(buttons, discordgo.Button{Label: "⚙️ Gérer la liste d'attente", Style: discordgo.SecondaryButton, CustomID: fmt.Sprintf("btn_manage_waitlist_%s", messageID)})
 	}
 	if confirmedCount > 0 {
-		rowComponents = append(rowComponents, discordgo.Button{Label: "🗑️ Retirer un participant", Style: discordgo.DangerButton, CustomID: fmt.Sprintf("btn_remove_participant_%s", messageID)})
+		buttons = append(buttons, discordgo.Button{Label: "🗑️ Retirer un participant", Style: discordgo.DangerButton, CustomID: fmt.Sprintf("btn_remove_participant_%s", messageID)})
 	}
 	var components []discordgo.MessageComponent
-	if len(rowComponents) > 0 {
-		components = append(components, discordgo.ActionsRow{Components: rowComponents})
+	for i := 0; i < len(buttons); i += buttonsPerRow {
+		end := min(i+buttonsPerRow, len(buttons))
+		components = append(components, discordgo.ActionsRow{Components: buttons[i:end]})
 	}
 	return components
 }

--- a/internal/adapters/discord/reaction.go
+++ b/internal/adapters/discord/reaction.go
@@ -65,7 +65,7 @@ func (h *Handler) HandleReactionJoin(s *discordgo.Session, channelID, messageID,
 		}
 	} else if isCasB(event.ScheduledAt, now) {
 		participant, _ := h.participantUseCase.GetParticipantByEventIDAndUserID(ctx, event.ID, userID)
-		if participant != nil {
+		if participant != nil && participant.Status == domain.StatusConfirmed {
 			if err := h.sendOrganizerAcceptRefuseDM(s, event.Title, event.CreatorID, channelID, messageID, participant); err != nil {
 				log.Printf("❌ Envoi MP Accepter/Refuser organisateur (Cas B): %v", err)
 			}
@@ -81,7 +81,7 @@ func (h *Handler) promoteNextFromWaitlist(s *discordgo.Session, ctx context.Cont
 		return
 	}
 	sendDM(s, luckyWinner.UserID, fmt.Sprintf("🎉 **Bonne nouvelle !** Une place s'est libérée pour **%s**, tu es maintenant parmi les confirmés !", event.Title))
-	if event.IsFinalized() {
+	if shouldGrantPrivateChannelOnPromote(event, time.Now()) {
 		grantPrivateChannelAccess(s, event.PrivateChannelID, luckyWinner.UserID)
 	}
 }

--- a/internal/ports/input/participant.go
+++ b/internal/ports/input/participant.go
@@ -11,7 +11,7 @@ type ParticipantUseCase interface {
 	LeaveEvent(ctx context.Context, eventID uint, userID string) (bool, error)
 	GetParticipantByEventIDAndUserID(ctx context.Context, eventID uint, userID string) (*entities.Participant, error)
 	GetParticipantByID(ctx context.Context, id uint) (*entities.Participant, error)
-	PromoteParticipant(ctx context.Context, participantID uint, creatorID string) (*entities.Participant, error)
+	PromoteParticipant(ctx context.Context, participantID uint, creatorID string) (*entities.Participant, bool, error)
 	RemoveParticipant(ctx context.Context, participantID uint, creatorID string) (*entities.Participant, error)
 	GetNextWaitlistParticipant(ctx context.Context, eventID uint) (*entities.Participant, error)
 }


### PR DESCRIPTION
- Refactored participant promotion logic to return a boolean indicating if the event's slot quota was increased.
- Updated Discord bot interaction handling for promoting participants from the waitlist, including improved messaging and error handling.
- Introduced new utility functions for displaying participant names and truncating labels in select menus.
- Enhanced the management of waitlist options in the Discord bot, ensuring better user experience and clarity.

This update improves the functionality and user engagement of the participant management system within the Discord bot.