### PR TITLE
refactor(BOT-51): improve error handling for event date/time parsing

### DIFF
--- a/internal/adapters/discord/modal_event_create.go
+++ b/internal/adapters/discord/modal_event_create.go
@@ -38,7 +38,12 @@ func (h *Handler) handleCreateEventModalSubmit(s *discordgo.Session, i *discordg
 	}
 	scheduledAt, err := pkgdiscord.ParseEventDateTime(dateStr, timeStr)
 	if err != nil {
-		respondEphemeral(s, i.Interaction, "❌ "+err.Error())
+		// When ParseEventDateTime returns a domain error, resolve it via i18n.
+		if msg := pkgdiscord.DomainErrorMessage(err); msg != "" {
+			respondEphemeral(s, i.Interaction, "❌ "+msg)
+		} else {
+			respondEphemeral(s, i.Interaction, "❌ "+err.Error())
+		}
 		return
 	}
 	slots, err := parseSlots(slotsStr)

--- a/internal/adapters/discord/modal_event_edit.go
+++ b/internal/adapters/discord/modal_event_edit.go
@@ -78,7 +78,13 @@ func (h *Handler) HandleEditModalSubmit(s *discordgo.Session, i *discordgo.Inter
 		var parseErr error
 		scheduledAt, parseErr = pkgdiscord.ParseEventDateTime(dateStr, timeStr)
 		if parseErr != nil {
-			respondEphemeral(s, i.Interaction, "❌ "+parseErr.Error())
+			// When the parsing error comes from the domain (e.g. date in the past),
+			// resolve it via the i18n adapter; otherwise, fall back to the raw error.
+			if msg := pkgdiscord.DomainErrorMessage(parseErr); msg != "" {
+				respondEphemeral(s, i.Interaction, "❌ "+msg)
+			} else {
+				respondEphemeral(s, i.Interaction, "❌ "+parseErr.Error())
+			}
 			return
 		}
 	}

--- a/internal/domain/errors.go
+++ b/internal/domain/errors.go
@@ -2,16 +2,49 @@ package domain
 
 import "errors"
 
-// Domain errors.
+// Error is the domain error type carrying a stable code.
+// The code is used by outer layers (adapters/i18n) to resolve
+// a localized, user-facing message.
+type Error struct {
+	code string
+}
+
+func (e *Error) Error() string {
+	// The error string is intentionally the machine-readable code.
+	// Adapters must not display this directly to end users.
+	return e.code
+}
+
+// Code returns the stable machine-readable code for this domain error.
+func (e *Error) Code() string {
+	return e.code
+}
+
+// Code extracts the domain error code from an error value.
+// Returns an empty string when the error is not a domain.Error.
+func Code(err error) string {
+	if err == nil {
+		return ""
+	}
+	var de *Error
+	if errors.As(err, &de) {
+		return de.code
+	}
+	return ""
+}
+
+// Domain error sentinels.
+// These are used with errors.Is and mapped to localized messages
+// by the adapters (i18n layer).
 var (
-	ErrEventNotFound           = errors.New("événement non trouvé")
-	ErrDateTimeInPast          = errors.New("la date et l'heure doivent être dans le futur")
-	ErrParticipantNotFound     = errors.New("participant non trouvé")
-	ErrParticipantExists       = errors.New("participant déjà inscrit")
-	ErrParticipantNotWaitlist  = errors.New("participant n'est pas en liste d'attente")
-	ErrParticipantNotConfirmed = errors.New("participant n'est pas confirmé")
-	ErrNoWaitlistParticipant   = errors.New("aucun participant en liste d'attente")
-	ErrCannotReduceSlots       = errors.New("impossible de réduire le nombre de places")
-	ErrNotOrganizer            = errors.New("seul l'organisateur peut effectuer cette action")
-	ErrEventAlreadyFinalized   = errors.New("cette sortie est déjà finalisée")
+	ErrEventNotFound           = &Error{code: "event_not_found"}
+	ErrDateTimeInPast          = &Error{code: "datetime_in_past"}
+	ErrParticipantNotFound     = &Error{code: "participant_not_found"}
+	ErrParticipantExists       = &Error{code: "participant_exists"}
+	ErrParticipantNotWaitlist  = &Error{code: "participant_not_waitlist"}
+	ErrParticipantNotConfirmed = &Error{code: "participant_not_confirmed"}
+	ErrNoWaitlistParticipant   = &Error{code: "no_waitlist_participant"}
+	ErrCannotReduceSlots       = &Error{code: "cannot_reduce_slots"}
+	ErrNotOrganizer            = &Error{code: "not_organizer"}
+	ErrEventAlreadyFinalized   = &Error{code: "event_already_finalized"}
 )

--- a/pkg/discord/errors.go
+++ b/pkg/discord/errors.go
@@ -1,0 +1,46 @@
+package discord
+
+import "servbot/internal/domain"
+
+// TranslateDomainError maps a domain error code to a user-facing message.
+// For now, messages are in French; this function is the single place to plug
+// a real i18n backend later.
+func TranslateDomainError(code string) string {
+	switch code {
+	case "event_not_found":
+		return "Événement non trouvé."
+	case "datetime_in_past":
+		return "la date et l'heure doivent être dans le futur"
+	case "participant_not_found":
+		return "Participant introuvable."
+	case "participant_exists":
+		return "Tu as déjà manifesté ton intérêt."
+	case "participant_not_waitlist":
+		return "Ce participant n'est plus en liste d'attente."
+	case "participant_not_confirmed":
+		return "Ce participant n'est pas confirmé."
+	case "no_waitlist_participant":
+		return "Il n'y a aucun participant en liste d'attente."
+	case "cannot_reduce_slots":
+		return "Impossible de réduire le nombre de places."
+	case "not_organizer":
+		return "Seul l'organisateur peut effectuer cette action."
+	case "event_already_finalized":
+		return "Cette sortie est déjà finalisée."
+	default:
+		return "Une erreur est survenue."
+	}
+}
+
+// DomainErrorMessage is a convenience helper that extracts the domain error code
+// and immediately resolves it to a user-facing message.
+func DomainErrorMessage(err error) string {
+	if err == nil {
+		return ""
+	}
+	if code := domain.Code(err); code != "" {
+		return TranslateDomainError(code)
+	}
+	return ""
+}
+


### PR DESCRIPTION
- Enhanced error responses in modal event creation and editing to utilize i18n for domain errors, providing user-friendly messages.
- Introduced a new domain error type with stable codes for better localization and error management.
- Added a utility function to translate domain error codes into user-facing messages, improving overall user experience.

This update ensures that users receive clearer and more relevant feedback when encountering errors related to event scheduling.